### PR TITLE
Add a link to the related tutorial

### DIFF
--- a/telehealth-example/README.md
+++ b/telehealth-example/README.md
@@ -15,7 +15,7 @@ To use the app, you need:
 
 ## Usage
 
-Read the [Getting Started](https://www.pubnub.com/docs/chat/components/ios) guide to learn how to use the app and better understand the logic behind it.
+Read the [tutorial](https://www.pubnub.com/tutorials/cross-platform-chat-application-telehealth-ios/) to learn how to use the app and better understand the logic behind it.
 
 ## Features
 


### PR DESCRIPTION
Linking to the GS guide may be misleading so I've changed the link to the related tutorial.